### PR TITLE
add optional https scheme

### DIFF
--- a/2020/debian-10/rootfs/opt/bitnami/scripts/libminioclient.sh
+++ b/2020/debian-10/rootfs/opt/bitnami/scripts/libminioclient.sh
@@ -19,6 +19,7 @@ export MINIO_CLIENT_BASEDIR="/opt/bitnami/minio-client"
 export MINIO_CLIENT_CONFIGDIR="/.mc"
 export MINIO_SERVER_HOST="${MINIO_SERVER_HOST:-}"
 export MINIO_SERVER_PORT_NUMBER="${MINIO_SERVER_PORT_NUMBER:-9000}"
+export MINIO_SERVER_SCHEME="${MINIO_SERVER_SCHEME:-http}"
 export MINIO_SERVER_ACCESS_KEY="${MINIO_SERVER_ACCESS_KEY:-}"
 export MINIO_SERVER_SECRET_KEY="${MINIO_SERVER_SECRET_KEY:-}"
 export PATH="${MINIO_CLIENT_BASEDIR}/bin:$PATH"
@@ -86,7 +87,7 @@ minio_client_execute_timeout() {
 minio_client_configure_server() {
     if [[ -n "$MINIO_SERVER_HOST" ]] && [[ -n "$MINIO_SERVER_ACCESS_KEY" ]] && [[ -n "$MINIO_SERVER_SECRET_KEY" ]]; then
         info "Adding Minio host to 'mc' configuration..."
-        minio_client_execute config host add minio "http://${MINIO_SERVER_HOST}:${MINIO_SERVER_PORT_NUMBER}" "${MINIO_SERVER_ACCESS_KEY}" "${MINIO_SERVER_SECRET_KEY}"
+        minio_client_execute config host add minio "${MINIO_SERVER_SCHEME}://${MINIO_SERVER_HOST}:${MINIO_SERVER_PORT_NUMBER}" "${MINIO_SERVER_ACCESS_KEY}" "${MINIO_SERVER_SECRET_KEY}"
     fi
 }
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Initialize the minio client with optional https scheme

**Benefits**

Use the bitnami/minio-client with minio server which use SSL/TLS connections.

- fixes https://github.com/bitnami/bitnami-docker-minio-client/issues/2